### PR TITLE
Always_use_presets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,5 +61,6 @@
         "thread": "cpp",
         "typeinfo": "cpp",
         "*.tpp": "cpp"
-    }
+    },
+    "cmake.useCMakePresets": "always"
 }


### PR DESCRIPTION
the vscode setting now include directive to always use CMakePresets